### PR TITLE
hostName変数の値を変更 ＋ port:4000 追加

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var browserSync = require('browser-sync');
 var plumber = require('gulp-plumber');
 var notify = require('gulp-notify');
 
-var hostName = "base.dev/";
+var hostName = "192.168.33.50";
 
 var dir = {
 	"base": "./public"
@@ -42,7 +42,8 @@ gulp.task('compass', function () {
 
 gulp.task('browser-sync', function () {
 	browserSync({
-		proxy: hostName
+		proxy: hostName,
+		port: 4000
 	});
 });
 


### PR DESCRIPTION
hostName変数の値を vagrantfile の ip の値と同じにしたところ、正しく動作できた。
また、念のために gulp.task の browser-sync に port: 4000 を追加した。
https://github.com/BrowserSync/browser-sync/issues/214

ご確認、よろしくお願いします。